### PR TITLE
Solr site filter feature

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -81,6 +81,22 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
  */
 function template_process_islandora_solr_metadata_display(array &$variables) {
   $variables['found'] = islandora_solr_metadata_query_fields($variables['islandora_object'], $variables['solr_fields']);
+  // Remove empty values.
+  if ($variables['found']) {
+    foreach ($variables['solr_fields'] as $solr_field=>$solr_field_array) {
+      if (isset($solr_field_array['value']) && is_array($solr_field_array['value'])) {
+        foreach ($solr_field_array['value'] as $k=>$val) {
+          if (trim($val) == '') {
+            unset($variables['solr_fields'][$solr_field]['value'][$k]);
+          }
+        }
+        // If no values left, also remove the field / label.
+        if (count($solr_field_array['value']) < 1) {
+          unset($variables['solr_fields'][$solr_field]);
+        }
+      }
+    }
+  }
   $variables['not_found_message'] = t('Document not present in Solr while generating the metadata display for @id. Try !reloading the page, or contact an administrator if this issue persists.', array(
     '@id' => $variables['islandora_object']->id,
     '!reloading' => '<a href="" onclick="window.location.reload(true)">' . t('reloading') . '</a>',
@@ -200,7 +216,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // modified to get around a bug in PHP 5.3.3 when used on CentOS 6.6,
         // otherwise the calling function doesn't maintain a reference to the
         // original value and it becomes a copy.
-        $get_display_value = function ($original_value) use ($solr_field, &$solr_fields) {
+        $get_display_value = function ($original_value) use ($solr_field, &$solr_fields, $object) {
           $value = $original_value;
           $field_config = (is_array($solr_fields[$solr_field]) ? $solr_fields[$solr_field] : array()) + array(
             'hyperlink' => 0,
@@ -228,12 +244,13 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
           if (is_callable($field_config['formatter'])) {
             $value = call_user_func($field_config['formatter'], $value);
           }
+
           if ($field_config['hyperlink'] == 1 && trim($value)) {
             if ($link_options = drupal_array_get_nested_value($field_config, array('link_options'))) {
               $use_value = $value;
               if (isset($link_options['link_text']) && $link_options['link_text'] == 'otherfield') {
-                $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
-
+                $target_object = islandora_object_load(str_replace('info:fedora/', '', $value)); 
+	
                 $site = _get_site_from_config();
                 $target_sites_rel = $target_object->relationships->get(NULL, 'isMemberOfSite');
                 $target_sites = array();
@@ -243,7 +260,6 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                   }
                 }
                 if ($site <> '' && array_search($site, $target_sites) === FALSE) {
-                  unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
                   return ;
                 }
 

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -202,7 +202,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // original value and it becomes a copy.
         $get_display_value = function ($original_value) use ($solr_field, &$solr_fields) {
           $value = $original_value;
-          $field_config = $solr_fields[$solr_field] + array(
+          $field_config = (is_array($solr_fields[$solr_field]) ? $solr_fields[$solr_field] : array()) + array(
             'hyperlink' => 0,
             'formatter' => NULL,
           );
@@ -235,7 +235,13 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                 $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
 
                 $site = _get_site_from_config();
-                $target_sites = $target_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfSite');
+                $target_sites_rel = $target_object->relationships->get(NULL, 'isMemberOfSite');
+                $target_sites = array();
+                foreach ($target_sites_rel as $tar) {
+                  if (isset($tar['object']['value'])) {
+                    $target_sites[] = 'info:fedora/' . $tar['object']['value'];
+                  }
+                }
                 if (array_search($site, $target_sites) === FALSE) {
                   unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
                   return ;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -242,7 +242,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                     $target_sites[] = 'info:fedora/' . $tar['object']['value'];
                   }
                 }
-                if (array_search($site, $target_sites) === FALSE) {
+                if ($site <> '' && array_search($site, $target_sites) === FALSE) {
                   unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
                   return ;
                 }
@@ -343,7 +343,8 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
 }
 
 /** 
- * Helper function to derive the site value from the islandora_solr_base_filter value
+ * Helper function to derive the site value from the islandora_solr_base_filter value.  Does not handle more than
+ * one site value in the base filter.
  */
 function _get_site_from_config() {
   $base_filter = variable_get('islandora_solr_base_filter');

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -229,6 +229,48 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
             $value = call_user_func($field_config['formatter'], $value);
           }
           if ($field_config['hyperlink'] == 1 && trim($value)) {
+            if ($link_options = drupal_array_get_nested_value($field_config, array('link_options'))) {
+              $use_value = $value;
+              if (isset($link_options['link_text']) && $link_options['link_text'] == 'otherfield') {
+                $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
+
+                $site = _get_site_from_config();
+                $target_sites = $target_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfSite');
+                if (array_search($site, $target_sites) === FALSE) {
+                  unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
+                  return ;
+                }
+
+                if ($target_object) {
+                  $use_target = 'islandora/object/' . $target_object->id;
+                  $use_value = ($link_options['link_text_options']['link_text_text']) ?
+                    _get_SOLR_field_value($target_object->id, $link_options['link_text_options']['link_text_text']) : $target_object->label;
+                }
+              }
+              if (!isset($link_options['link_target']) || $link_options['link_target'] == 'SOLR') {
+                if (variable_get('islandora_solr_metadata_omit_empty_values', FALSE) && !trim($value)) {
+                  // Avoid generating markup (throwing off the "empty" check).
+                  // Will get stripped out later.
+                  return;
+                }
+                $solr_query = format_string('!field:!value', array(
+                  '!field' => $solr_field,
+                  '!value' => islandora_solr_facet_escape($original_value),
+                ));
+                return l($use_value, 'islandora/search', array(
+                  "query" => array(
+                    "type" => "dismax",
+                    "f" => array(
+                      $solr_query,
+                    ),
+                  ),
+                ));
+              }
+              else {
+                // Based on the config, see what the target is.
+                return ($use_target) ? l($use_value, $use_target) : $use_value;
+              }
+            }
             if (variable_get('islandora_solr_metadata_omit_empty_values', FALSE) && !trim($value)) {
               // Avoid generating markup (throwing off the "empty" check).
               // Will get stripped out later.
@@ -293,3 +335,41 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
     }
   }
 }
+
+/** 
+ * Helper function to derive the site value from the islandora_solr_base_filter value
+ */
+function _get_site_from_config() {
+  $base_filter = variable_get('islandora_solr_base_filter');
+  // look for the value for RELS_EXT_isMemberOfSite_uri_ms 
+  $filters = explode("\r\n", $base_filter);
+  $found_filter = '';
+  foreach ($filters as $filter) { 
+    if (strstr($filter, 'RELS_EXT_isMemberOfSite_uri_ms') <> '') {
+      $found_filter = $filter;
+    }  
+  }
+  if ($found_filter) { 
+    $site = str_replace(array('"', 'RELS_EXT_isMemberOfSite_uri_ms:'), '', $found_filter);
+    return $site;
+  }
+}
+
+
+/**
+ * Helper function to get a SOLR value for a given PID.
+ */
+function _get_SOLR_field_value($pid, $field) {
+  $query_processor = new IslandoraSolrQueryProcessor();
+  $query_processor->solrQuery = 'PID:"' . $pid . '"';
+  $query_processor->solrParams['fl'] = $field;
+  $query_processor->executeQuery(FALSE);
+  if ($query_processor->islandoraSolrResult['response']['numFound'] > 0) {
+    $solr_results_doc = $query_processor->islandoraSolrResult['response']['objects']['0']['solr_doc'];
+    return (!is_array($solr_results_doc[$field])) ? $solr_results_doc[$field] : $solr_results_doc[$field][0];
+  }
+  else {
+    return false;
+  }
+}
+


### PR DESCRIPTION
Add the ability to filter solr queries based on the site so each will not access to different sites metadata. Allows to break out our sites into 3 more easily.